### PR TITLE
[elasticsearch-5.6.6] Update Elasticsearch Docker image to version 5.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,15 @@ FROM openjdk:8-jre
 MAINTAINER Jorge Acetozi
 
 # Define default environment variables
-ENV ELASTICSEARCH_VERSION=2.3.5
+ENV ELASTICSEARCH_VERSION=5.6.6
 ENV ELASTICSEARCH_HOME=/opt/elasticsearch
-ENV ES_HEAP_SIZE=1024m
-ENV IS_MASTER_ELEGIBLE_NODE=true
-ENV IS_DATA_NODE=true
-ENV LOCK_MEMORY=false
-ENV MINIMUM_MASTER_NODES=1
 
 # Create elasticsearch group and user
 RUN groupadd -g 1000 elasticsearch \
   && useradd -d "$ELASTICSEARCH_HOME" -u 1000 -g 1000 -s /sbin/nologin elasticsearch
 
-# Install Elasticsearch 2.3.5
-RUN wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ELASTICSEARCH_VERSION/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz -P /opt \
+# Install Elasticsearch 5.6.6
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz -P /opt \
   && cd /opt \
   && tar xvzf elasticsearch-$ELASTICSEARCH_VERSION.tar.gz \
   && mv elasticsearch-$ELASTICSEARCH_VERSION elasticsearch \
@@ -31,8 +26,8 @@ WORKDIR $ELASTICSEARCH_HOME
 # Add initialization script
 ADD bin/docker-entrypoint.sh bin/docker-entrypoint.sh
 
-# Add Elasticsearch template configuration file
-ADD config/elasticsearch.yml config/elasticsearch.yml
+# Add configuration files
+ADD config/* config/
 
 # Change directories ownership to elasticsearch user and group
 RUN chown -R elasticsearch:elasticsearch $ELASTICSEARCH_HOME /var/data/elasticsearch /var/log/elasticsearch
@@ -41,14 +36,14 @@ RUN chown -R elasticsearch:elasticsearch $ELASTICSEARCH_HOME /var/data/elasticse
 USER elasticsearch
 
 # Install Elasticsearch monitoring plugins
-RUN ./bin/plugin install mobz/elasticsearch-head \
-  && ./bin/plugin install royrusso/elasticsearch-HQ
+# RUN ./bin/plugin install mobz/elasticsearch-head \
+#  && ./bin/plugin install royrusso/elasticsearch-HQ
 
 # Define mountable directories
 VOLUME /var/data/elasticsearch
 VOLUME /var/log/elasticsearch
 
-# Exposes http ports
+# Exposes ports
 EXPOSE 9200 9300
 
 # Define main command

--- a/README.md
+++ b/README.md
@@ -1,44 +1,25 @@
-# Bootstrap a 3-node Elasticsearch cluster locally using Docker
-- **Start node1**
+# Elasticsearch 5.6.6 Docker Image
 
-`$ docker rm -f node1 || true && docker run -d --name node1 --net=host --privileged -p 9200-9400:9200-9400 -e CLUSTER_NAME=my-cluster -e NODE_NAME=node1 -e LOCK_MEMORY=true --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -e ES_HEAP_SIZE=512m jorgeacetozi/elasticsearch:2.3.5`
-
-- **Start node2**
-
-`$ docker rm -f node2 || true && docker run -d --name node2 --net=host --privileged -p 9200-9400:9200-9400 -e CLUSTER_NAME=my-cluster -e NODE_NAME=node2 -e LOCK_MEMORY=true --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -e ES_HEAP_SIZE=512m jorgeacetozi/elasticsearch:2.3.5`
-
-- **Start node3**
-
-`$ docker rm -f node3 || true && docker run -d --name node3 --net=host --privileged -p 9200-9400:9200-9400 -e CLUSTER_NAME=my-cluster -e NODE_NAME=node3 -e LOCK_MEMORY=true --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -e ES_HEAP_SIZE=512m jorgeacetozi/elasticsearch:2.3.5`
-
-Now just issue `http://localhost:9200/_plugin/head` in the browser.
-
-# Bootstrap a 3-node Elasticsearch cluster using Vagrant
-Just clone my GitHub repository and vagrant up!
+## Bootstrap a 3-node Elasticsearch cluster using Vagrant
+Just clone this GitHub repository and execute `vagrant up`!
 
 - `$ git clone git@github.com:jorgeacetozi/elasticsearch-docker-image.git`
 - `$ cd elasticsearch-docker-image/vagrant`
 - `$ vagrant up`
 
-Now just issue `http://10.0.0.10:9200/_plugin/head` in the browser.
+Issue an HTTP GET to `http://10.0.0.10:9200/` and... You Know, for Search ;)
 
-# How to increase Elasticsearch memory heap size?
-Just tune the **ES_HEAP_SIZE** environment variable in the **docker run** statement in order to fit your needs. For instance:
-- **Increase the JVM Heap Size to 10g:** "docker run ... -e ES_HEAP_SIZE=10g ..."
+## How to increase Elasticsearch memory heap size?
+Just tune `Xms` and `Xmx` values in `jvm.options` configuration file.
 
-# How to backup data and log files using volumes?
-Just use the `-v` instruction in the **docker run** instruction:
-- Elasticsearch Data: `docker run... -v your_data_directory:/var/data/elasticsearch ...`
-- Elasticsearch Logs: `docker run... -v your_log_directory:/var/log/elasticsearch ...`
+## How to backup data and log files using volumes?
+Just use the `-v` instruction in the **docker container run** instruction:
+- Elasticsearch Data: `docker container run... -v your_data_directory:/var/data/elasticsearch ...`
+- Elasticsearch Logs: `docker container run... -v your_log_directory:/var/log/elasticsearch ...`
 
-# Docker Run Parameters
-This image support some level of customization by using environment variables in the `docker run` instruction to dynamically modify the `elasticsearch.yml` configuration file:
+## Docker Container Run Parameters
+This image support some level of customization by using environment variables in the `docker container run` instruction to dynamically modify the `elasticsearch.yml` configuration file:
 - **CLUSTER_NAME**: set the cluster name (should be the same among all nodes in the cluster)
 - **NODE_NAME**: specific name of the node itself.
-- **IS_MASTER_ELEGIBLE_NODE**: specify whether the node is master elegible or not (true/false). Default is true (see the Dockerfile)
-- **IS_DATA_NODE**: specify whether the node can handle indexing/querying operations or not (true/false). Default is true (see the Dockerfile)
-- **ES_HEAP_SIZE**: modify JVM memory heap size. Default is 1024m
-- **LOCK_MEMORY**: lock memory at Elasticsearch startup in order to avoid swapping (true/false). Default is false (see the Dockerfile)
-- **NETWORK_HOST**: the IP that the node will publish itself so that other nodes can reach it. For instance, in Vagrant it must be the VM instance IP. In AWS it must be the EC2 instance private IP, and so on. When running Docker locally you don't need to specify it because both containers will run in the same host
+- **NETWORK_HOST**: the IP that the node will publish itself so that other nodes can reach it. For instance, in Vagrant it must be the VM instance IP. In AWS it must be the EC2 instance private IP, and so on. When running Docker locally you don't need to specify it because both containers will run in the same host.
 - **UNICAST_HOSTS**: the list of cluster initial nodes using the format **IP:PORT, IP:PORT, IP:PORT**
-- **MINIMUM_MASTER_NODES**: the minimum number of master elegible nodes that a node need to "see" (including itself) to be able to take part in a master election (configure this correctly in order to avoid a split-brain scenario)

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -3,12 +3,8 @@ set -e
 
 sed -i "s/CLUSTER_NAME/$CLUSTER_NAME/
   s/NODE_NAME/$NODE_NAME/
-  s/IS_MASTER_ELEGIBLE_NODE/$IS_MASTER_ELEGIBLE_NODE/
-  s/IS_DATA_NODE/$IS_DATA_NODE/
-  s/LOCK_MEMORY/$LOCK_MEMORY/
   s/NETWORK_HOST/$NETWORK_HOST/
-  s/UNICAST_HOSTS/$UNICAST_HOSTS/
-  s/MINIMUM_MASTER_NODES/$MINIMUM_MASTER_NODES/" ./config/elasticsearch.yml
+  s/UNICAST_HOSTS/$UNICAST_HOSTS/" ./config/elasticsearch.yml
 
 echo -e "Starting Elasticsearch $ELASTICSEARCH_VERSION"
 exec /opt/elasticsearch/bin/elasticsearch

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,23 +1,88 @@
 # ======================== Elasticsearch Configuration =========================
-
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please consult the documentation for further information on configuration options:
+# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+#
 # ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
 cluster.name: CLUSTER_NAME
-
+#
 # ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+#
 node.name: NODE_NAME
-node.master: IS_MASTER_ELEGIBLE_NODE
-node.data: IS_DATA_NODE
-
+#
+# Add custom attributes to the node:
+#
+#node.attr.rack: r1
+#
 # ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
 path.data: /var/data/elasticsearch
+#
+# Path to log files:
+#
 path.logs: /var/log/elasticsearch
-
+#
 # ----------------------------------- Memory -----------------------------------
-bootstrap.mlockall: LOCK_MEMORY
-
+#
+# Lock the memory on startup:
+#
+#bootstrap.memory_lock: true
+#
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
 # ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
 network.host: NETWORK_HOST
-
+#
+# Set a custom port for HTTP:
+#
+#http.port: 9200
+#
+# For more information, consult the network module documentation.
+#
 # --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
 discovery.zen.ping.unicast.hosts: UNICAST_HOSTS
-discovery.zen.minimum_master_nodes: MINIMUM_MASTER_NODES
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+#
+#discovery.zen.minimum_master_nodes: 3
+#
+# For more information, consult the zen discovery module documentation.
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+#gateway.recover_after_nodes: 3
+#
+# For more information, consult the gateway module documentation.
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Require explicit names when deleting indices:
+#
+#action.destructive_requires_name: true

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -1,0 +1,111 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms256m
+-Xmx256m
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -1,0 +1,74 @@
+status = error
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+appender.rolling.type = RollingFile
+appender.rolling.name = rolling
+appender.rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+rootLogger.appenderRef.rolling.ref = rolling
+
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_rolling
+appender.deprecation_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.deprecation_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 1GB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 4
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
+logger.deprecation.additivity = false
+
+appender.index_search_slowlog_rolling.type = RollingFile
+appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
+appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
+appender.index_search_slowlog_rolling.layout.type = PatternLayout
+appender.index_search_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
+appender.index_search_slowlog_rolling.policies.type = Policies
+appender.index_search_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_search_slowlog_rolling.policies.time.interval = 1
+appender.index_search_slowlog_rolling.policies.time.modulate = true
+
+logger.index_search_slowlog_rolling.name = index.search.slowlog
+logger.index_search_slowlog_rolling.level = trace
+logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref = index_search_slowlog_rolling
+logger.index_search_slowlog_rolling.additivity = false
+
+appender.index_indexing_slowlog_rolling.type = RollingFile
+appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
+appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
+appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
+appender.index_indexing_slowlog_rolling.policies.type = Policies
+appender.index_indexing_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_indexing_slowlog_rolling.policies.time.interval = 1
+appender.index_indexing_slowlog_rolling.policies.time.modulate = true
+
+logger.index_indexing_slowlog.name = index.indexing.slowlog.index
+logger.index_indexing_slowlog.level = trace
+logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
+logger.index_indexing_slowlog.additivity = false

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$script = <<SCRIPT
+sysctl -w vm.max_map_count=262144
+SCRIPT
+
 Vagrant.configure("2") do |config|
   config.vm.box = "coreos-alpha"
 
@@ -11,61 +15,57 @@ Vagrant.configure("2") do |config|
   config.vm.define "elasticsearch_node1" do |node1|
     node1.vm.hostname = "node1"
     node1.vm.network "private_network", ip: "10.0.0.10"
+    node1.vm.provision "shell", inline: $script
     node1.vm.provision "shell",
-        inline: "docker rm -f node1 || true && docker run -d \
+        inline: "docker container rm -f node1 || true && docker container run -d \
                    --name node1 \
                    --net=host \
                    --privileged \
                    -p 9200-9400:9200-9400 \
                    -e CLUSTER_NAME=my-cluster \
                    -e NODE_NAME=node1 \
-                   -e LOCK_MEMORY=true \
                    --ulimit memlock=-1:-1 \
                    --ulimit nofile=65536:65536 \
                    -e NETWORK_HOST=10.0.0.10 \
                    -e UNICAST_HOSTS='10.0.0.10:9300, 10.0.0.20:9300, 10.0.0.30:9300' \
-                   -e ES_HEAP_SIZE=512m \
-                   jorgeacetozi/elasticsearch:2.3.5"
+                   jorgeacetozi/elasticsearch:5.6.6"
   end
 
   config.vm.define "elasticsearch_node2" do |node2|
     node2.vm.hostname = "node2"
     node2.vm.network "private_network", ip: "10.0.0.20"
+    node2.vm.provision "shell", inline: $script
     node2.vm.provision "shell",
-        inline: "docker rm -f node2 || true && docker run -d \
+        inline: "docker container rm -f node2 || true && docker container run -d \
                    --name node2 \
                    --net=host \
                    --privileged \
                    -p 9200-9400:9200-9400 \
                    -e CLUSTER_NAME=my-cluster \
                    -e NODE_NAME=node2 \
-                   -e LOCK_MEMORY=true \
                    --ulimit memlock=-1:-1 \
                    --ulimit nofile=65536:65536 \
                    -e NETWORK_HOST=10.0.0.20 \
                    -e UNICAST_HOSTS='10.0.0.10:9300, 10.0.0.20:9300, 10.0.0.30:9300' \
-                   -e ES_HEAP_SIZE=512m \
-                   jorgeacetozi/elasticsearch:2.3.5"
+                   jorgeacetozi/elasticsearch:5.6.6"
   end
 
   config.vm.define "elasticsearch_node3" do |node3|
     node3.vm.hostname = "node3"
     node3.vm.network "private_network", ip: "10.0.0.30"
+    node3.vm.provision "shell", inline: $script
     node3.vm.provision "shell",
-        inline: "docker rm -f node3 || true && docker run -d \
+        inline: "docker container rm -f node3 || true && docker container run -d \
                    --name node3 \
                    --net=host \
                    --privileged \
                    -p 9200-9400:9200-9400 \
                    -e CLUSTER_NAME=my-cluster \
                    -e NODE_NAME=node3 \
-                   -e LOCK_MEMORY=true \
                    --ulimit memlock=-1:-1 \
                    --ulimit nofile=65536:65536 \
                    -e NETWORK_HOST=10.0.0.30 \
                    -e UNICAST_HOSTS='10.0.0.10:9300, 10.0.0.20:9300, 10.0.0.30:9300' \
-                   -e ES_HEAP_SIZE=512m \
-                   jorgeacetozi/elasticsearch:2.3.5"
+                   jorgeacetozi/elasticsearch:5.6.6"
   end
-
 end


### PR DESCRIPTION
Changelog
---------
- Update Elasticsearch Docker image to version 5.6.6
- Update Vagrantfile to use the updated image
- Update README.md to expose changes